### PR TITLE
fix: Arabic azkar with English reference handling

### DIFF
--- a/app/src/main/java/com/app/azkary/ui/reading/AzkarReadingItem.kt
+++ b/app/src/main/java/com/app/azkary/ui/reading/AzkarReadingItem.kt
@@ -19,6 +19,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalLayoutDirection
@@ -28,11 +29,13 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDirection
 import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.app.azkary.R
 import com.app.azkary.data.model.AzkarItemUi
+import com.app.azkary.util.BidiHelper
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -113,6 +116,12 @@ private fun ReadingSectionLtr(
     titleColor: androidx.compose.ui.graphics.Color
 ) {
     val colors = MaterialTheme.colorScheme
+    val context = LocalContext.current
+
+    // Format content with proper bidirectional handling for mixed text
+    val formattedContent = remember(content, context) {
+        BidiHelper.formatMixedText(content, context)
+    }
 
     Column(
         modifier = Modifier
@@ -131,7 +140,7 @@ private fun ReadingSectionLtr(
         Spacer(modifier = Modifier.height(6.dp))
 
         LtrText(
-            text = content,
+            text = formattedContent,
             style = MaterialTheme.typography.bodyMedium.copy(
                 color = colors.onBackground.copy(alpha = 0.9f),
                 lineHeight = 22.sp,
@@ -144,6 +153,13 @@ private fun ReadingSectionLtr(
 @Composable
 private fun HadithInformationCardLtr(referenceText: String) {
     val colors = MaterialTheme.colorScheme
+    val context = LocalContext.current
+
+    // Format reference text with proper bidirectional handling
+    // This handles mixed Arabic/English references correctly
+    val formattedReference = remember(referenceText, context) {
+        BidiHelper.formatVerseReference(referenceText, context)
+    }
 
     Card(
         colors = CardDefaults.cardColors(containerColor = colors.surfaceVariant.copy(alpha = 0.5f)),
@@ -152,7 +168,7 @@ private fun HadithInformationCardLtr(referenceText: String) {
     ) {
         Column(modifier = Modifier.padding(16.dp)) {
             LtrText(
-                text = referenceText,
+                text = formattedReference,
                 style = MaterialTheme.typography.bodySmall.copy(
                     color = colors.onSurfaceVariant.copy(alpha = 0.85f),
                     lineHeight = 18.sp,

--- a/app/src/test/java/com/app/azkary/util/BidiHelperTest.kt
+++ b/app/src/test/java/com/app/azkary/util/BidiHelperTest.kt
@@ -451,4 +451,101 @@ class BidiHelperTest {
             assertTrue(result.contains("10"))
         }
     }
+
+    // ==================== Arabic with English Reference Tests (Issue #12) ====================
+
+    @Test
+    fun `formatVerseReference handles Arabic text with English reference for RTL locale`() {
+        setLocale(Locale("ar"))
+
+        // Mixed Arabic text with English hadith reference
+        val mixedReference = "[البخاري 5074]"
+        val result = BidiHelper.formatVerseReference(mixedReference, mockContext)
+
+        assertFalse(result.isEmpty())
+        assertTrue(result.contains("البخاري"))
+        assertTrue(result.contains("5074"))
+    }
+
+    @Test
+    fun `formatVerseReference handles Arabic text with English reference for LTR locale`() {
+        setLocale(Locale("en"))
+
+        // Mixed Arabic text with English hadith reference
+        val mixedReference = "[البخاري 5074]"
+        val result = BidiHelper.formatVerseReference(mixedReference, mockContext)
+
+        assertFalse(result.isEmpty())
+        assertTrue(result.contains("البخاري"))
+        assertTrue(result.contains("5074"))
+    }
+
+    @Test
+    fun `formatMixedText handles Arabic zikr with English reference`() {
+        setLocale(Locale("ar"))
+
+        // Arabic zikr with English reference
+        val mixedText = "رواه البخاري [Bukhari 123] ومسلم [Muslim 456]"
+        val result = BidiHelper.formatMixedText(mixedText, mockContext)
+
+        assertFalse(result.isEmpty())
+        assertTrue(result.contains("البخاري"))
+        assertTrue(result.contains("Bukhari"))
+        assertTrue(result.contains("مسلم"))
+        assertTrue(result.contains("Muslim"))
+    }
+
+    @Test
+    fun `formatMixedText handles complex mixed content with numbers and Latin`() {
+        setLocale(Locale("ar"))
+
+        // Complex mixed content: Arabic + English + numbers
+        val complexText = "سبحان الله 33 مرة - [Tirmidhi 3567]"
+        val result = BidiHelper.formatMixedText(complexText, mockContext)
+
+        assertFalse(result.isEmpty())
+        assertTrue(result.contains("سبحان الله"))
+        assertTrue(result.contains("33"))
+        assertTrue(result.contains("Tirmidhi"))
+        assertTrue(result.contains("3567"))
+    }
+
+    @Test
+    fun `formatAsLtr handles Arabic text with LTR forced direction`() {
+        setLocale(Locale("ar"))
+
+        // Arabic text that should be forced LTR (like references)
+        val arabicText = "[البخاري 5074]"
+        val result = BidiHelper.formatAsLtr(arabicText, mockContext)
+
+        assertFalse(result.isEmpty())
+        assertTrue(result.contains("البخاري"))
+        assertTrue(result.contains("5074"))
+    }
+
+    @Test
+    fun `formatMixedText handles English reference in Arabic context`() {
+        setLocale(Locale("ar"))
+
+        // English reference only, displayed in Arabic context
+        val englishReference = "[Bukhari 5074]"
+        val result = BidiHelper.formatMixedText(englishReference, mockContext)
+
+        assertFalse(result.isEmpty())
+        assertTrue(result.contains("Bukhari"))
+        assertTrue(result.contains("5074"))
+    }
+
+    @Test
+    fun `formatVerseReference handles nested brackets`() {
+        setLocale(Locale("ar"))
+
+        // Reference with nested brackets
+        val nestedReference = "[رواه البخاري (كتاب الصلاة) 123]"
+        val result = BidiHelper.formatVerseReference(nestedReference, mockContext)
+
+        assertFalse(result.isEmpty())
+        assertTrue(result.contains("البخاري"))
+        assertTrue(result.contains("123"))
+    }
 }


### PR DESCRIPTION
## Description
Fixes #12 - Proper RTL/LTR handling for Arabic azkar with English references.

## Changes
- Updated AzkarReadingItem.kt to use BidiHelper.formatMixedText()
- Added 7 new test cases for mixed Arabic/English reference handling

## Testing
- Unit tests pass for mixed text handling
- Edge cases covered (nested brackets, complex mixed content)