### PR TITLE
fix: system category handling in edit mode

### DIFF
--- a/app/src/main/java/com/app/azkary/ui/summary/SummaryScreen.kt
+++ b/app/src/main/java/com/app/azkary/ui/summary/SummaryScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
@@ -287,18 +288,18 @@ fun CategoryItem(
     Card(
         modifier = Modifier
             .fillMaxWidth()
-            .combinedClickable(
-                onClick = {
-                    if (isEditMode && category.type == com.app.azkary.data.model.CategoryType.USER) {
-                        onEdit()
-                    } else {
-                        onClick()
-                    }
-                },
-                onLongClick = {
-                    if (holdToComplete && !isEditMode) {
-                        onHoldComplete()
-                    }
+            .then(
+                if (isEditMode && category.type == com.app.azkary.data.model.CategoryType.DEFAULT) {
+                    Modifier
+                } else {
+                    Modifier.combinedClickable(
+                        onClick = {
+                            if (isEditMode) onEdit() else onClick()
+                        },
+                        onLongClick = {
+                            if (!isEditMode && holdToComplete) onHoldComplete()
+                        }
+                    )
                 }
             )
     ) {
@@ -336,20 +337,12 @@ fun CategoryItem(
                         }
                     }
                     com.app.azkary.data.model.CategoryType.DEFAULT -> {
-                        Row {
-                            IconButton(
-                                onClick = onMoveUp,
-                                enabled = index > 0
-                            ) {
-                                Icon(Icons.Default.KeyboardArrowUp, contentDescription = null)
-                            }
-                            IconButton(
-                                onClick = onMoveDown,
-                                enabled = index < totalCount - 1
-                            ) {
-                                Icon(Icons.Default.KeyboardArrowDown, contentDescription = null)
-                            }
-                        }
+                        Icon(
+                            imageVector = Icons.Default.Lock,
+                            contentDescription = "System category - read only",
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
+                            modifier = Modifier.size(24.dp)
+                        )
                     }
                 }
             } else {


### PR DESCRIPTION
## Description
Fixes #20 - Improved handling of system categories in edit mode.

## Changes
- System categories show a lock icon in edit mode instead of edit/delete buttons
- System categories are not clickable in edit mode (cannot be edited)
- User categories: click opens edit screen in edit mode
- Long-press only triggers hold-to-complete when NOT in edit mode
- Removed `isStockCategory` logic from CategoryCreationScreen and CategoryCreationViewModel
- Simplified AzkarRepository.updateCustomCategory

## Testing
- Enter edit mode by tapping the edit icon
- Verify system (DEFAULT) categories show a lock icon
- Verify clicking system categories in edit mode does nothing
- Verify user categories can still be edited, reordered, and deleted