### PR TITLE
fix: remove non-existent labels from dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,6 @@ updates:
     open-pull-requests-limit: 10
     reviewers:
       - "KareemSarhan"
-    labels:
-      - "dependencies"
     commit-message:
       prefix: "chore"
       include: "scope"
@@ -22,9 +20,6 @@ updates:
     open-pull-requests-limit: 5
     reviewers:
       - "KareemSarhan"
-    labels:
-      - "dependencies"
-      - "github-actions"
     commit-message:
       prefix: "chore"
       include: "scope"


### PR DESCRIPTION
Fix Dependabot error by removing labels that don't exist