### PR TITLE
fix: prevent crash when day changes while on reading page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@
 local.properties
 *.log
 
+# Worktrees
+.worktrees/
+
 # Release artifacts
 /app/release/
 

--- a/app/src/main/java/com/app/azkary/MainActivity.kt
+++ b/app/src/main/java/com/app/azkary/MainActivity.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
@@ -27,6 +28,7 @@ import com.app.azkary.data.prefs.ThemePreferencesRepository
 import com.app.azkary.data.prefs.ThemeSettings
 import com.app.azkary.data.repository.AzkarRepository
 import com.app.azkary.domain.AppRatingManager
+import com.app.azkary.domain.IslamicDateProvider
 import com.app.azkary.notification.AzkarNotificationManager
 import com.app.azkary.ui.reading.ReadingScreen
 import com.app.azkary.ui.settings.SettingsScreen
@@ -37,6 +39,7 @@ import com.app.azkary.util.AppUpdateManager
 import com.app.azkary.util.AppUpdateManagerFactory
 import com.app.azkary.util.LocaleManager
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 import androidx.compose.ui.unit.LayoutDirection as ComposeLayoutDirection
 
@@ -49,6 +52,7 @@ class MainActivity : ComponentActivity() {
     @Inject lateinit var localeManager: LocaleManager
     @Inject lateinit var appRatingManager: AppRatingManager
     @Inject lateinit var appUpdateManagerFactory: AppUpdateManagerFactory
+    @Inject lateinit var islamicDateProvider: IslamicDateProvider
 
     private lateinit var appUpdateManager: AppUpdateManager
 
@@ -170,6 +174,9 @@ class MainActivity : ComponentActivity() {
         super.onResume()
         appUpdateManager.onResume()
         localeManager.notifyLocaleChanged()
+        lifecycleScope.launch {
+            islamicDateProvider.refreshDate()
+        }
     }
 
     override fun onDestroy() {

--- a/app/src/main/java/com/app/azkary/domain/IslamicDateProvider.kt
+++ b/app/src/main/java/com/app/azkary/domain/IslamicDateProvider.kt
@@ -2,6 +2,9 @@ package com.app.azkary.domain
 
 import com.app.azkary.data.prefs.UserPreferencesRepository
 import com.app.azkary.data.repository.PrayerTimesRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import java.time.LocalDate
 import javax.inject.Inject
@@ -12,6 +15,9 @@ class IslamicDateProvider @Inject constructor(
     private val prayerTimesRepository: PrayerTimesRepository,
     private val userPreferencesRepository: UserPreferencesRepository
 ) {
+    private val _currentDate = MutableStateFlow<LocalDate?>(null)
+    val currentDateFlow: StateFlow<LocalDate?> = _currentDate.asStateFlow()
+
     suspend fun getCurrentDate(): LocalDate {
         val locationPrefs = userPreferencesRepository.locationPreferences.first()
 
@@ -29,5 +35,9 @@ class IslamicDateProvider @Inject constructor(
         } catch (e: Exception) {
             LocalDate.now()
         }
+    }
+
+    suspend fun refreshDate() {
+        _currentDate.value = getCurrentDate()
     }
 }

--- a/app/src/main/java/com/app/azkary/ui/reading/ReadingViewModel.kt
+++ b/app/src/main/java/com/app/azkary/ui/reading/ReadingViewModel.kt
@@ -13,15 +13,16 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import javax.inject.Inject
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -36,9 +37,9 @@ class ReadingViewModel @Inject constructor(
 ) : ViewModel() {
     val categoryId: String? = savedStateHandle["categoryId"]
 
-    private val todayFlow: Flow<String> = flow {
-        emit(islamicDateProvider.getCurrentDate().toString())
-    }
+    private val todayFlow: Flow<String> = islamicDateProvider.currentDateFlow
+        .filterNotNull()
+        .map { it.toString() }
 
     val holdToComplete: StateFlow<Boolean> = userPreferencesRepository.holdToComplete
         .stateIn(
@@ -58,6 +59,9 @@ class ReadingViewModel @Inject constructor(
     val vibrationEnabledInternal = _vibrationEnabledInternal.asStateFlow()
 
     init {
+        viewModelScope.launch {
+            islamicDateProvider.refreshDate()
+        }
         viewModelScope.launch {
             userPreferencesRepository.vibrationEnabled.collect { enabled ->
                 _vibrationEnabledInternal.value = enabled
@@ -109,7 +113,8 @@ class ReadingViewModel @Inject constructor(
     fun incrementRepeat(itemId: String) {
         viewModelScope.launch {
             val id = categoryId ?: return@launch
-            val today = islamicDateProvider.getCurrentDate().toString()
+            val today = islamicDateProvider.currentDateFlow.value?.toString()
+                ?: islamicDateProvider.getCurrentDate().toString()
             repository.incrementRepeat(id, itemId, today)
         }
     }
@@ -117,7 +122,8 @@ class ReadingViewModel @Inject constructor(
     fun markItemComplete(itemId: String) {
         viewModelScope.launch {
             val id = categoryId ?: return@launch
-            val today = islamicDateProvider.getCurrentDate().toString()
+            val today = islamicDateProvider.currentDateFlow.value?.toString()
+                ?: islamicDateProvider.getCurrentDate().toString()
             repository.markItemComplete(id, itemId, today)
         }
     }

--- a/app/src/main/java/com/app/azkary/ui/summary/SummaryViewModel.kt
+++ b/app/src/main/java/com/app/azkary/ui/summary/SummaryViewModel.kt
@@ -22,9 +22,9 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.Job
@@ -48,7 +48,7 @@ class SummaryViewModel @Inject constructor(
 ) : ViewModel() {
 
     val categories: StateFlow<List<CategoryUi>> = localeManager.currentLangTagFlow.flatMapLatest { lang ->
-        flow { emit(islamicDateProvider.getCurrentDate().toString()) }.flatMapLatest { date ->
+        islamicDateProvider.currentDateFlow.filterNotNull().map { it.toString() }.flatMapLatest { date ->
             repository.observeCategoriesWithDisplayName(
                 langTag = lang,
                 date = date
@@ -161,6 +161,9 @@ class SummaryViewModel @Inject constructor(
 
     init {
         println("DEBUG: SummaryViewModel - ViewModel initialized")
+        viewModelScope.launch {
+            islamicDateProvider.refreshDate()
+        }
         // Auto-refresh prayer times when ViewModel is created and location is enabled
         locationPreferencesJob = viewModelScope.launch {
             userPreferencesRepository.locationPreferences.collect { prefs ->
@@ -261,7 +264,8 @@ class SummaryViewModel @Inject constructor(
     fun toggleCategoryCompletion(categoryId: String) {
         viewModelScope.launch {
             val category = categories.first().find { it.id == categoryId } ?: return@launch
-            val today = islamicDateProvider.getCurrentDate().toString()
+            val today = islamicDateProvider.currentDateFlow.value?.toString()
+                ?: islamicDateProvider.getCurrentDate().toString()
 
             if (category.progress >= 1f) {
                 repository.markCategoryIncomplete(categoryId, today)

--- a/app/src/test/java/com/app/azkary/domain/IslamicDateProviderTest.kt
+++ b/app/src/test/java/com/app/azkary/domain/IslamicDateProviderTest.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 import java.time.LocalDate
@@ -247,4 +248,49 @@ class IslamicDateProviderTest {
         // Assert - Should fallback to Gregorian date
         assertEquals(LocalDate.now(), result)
     }
+
+    @Test
+    fun `currentDateFlow should be null initially`() = runTest {
+        assertNull(islamicDateProvider.currentDateFlow.value)
+    }
+
+    @Test
+    fun `refreshDate should update currentDateFlow`() = runTest {
+        val mockLocation = mockk<LatLng> {
+            every { latitude } returns 30.0444
+            every { longitude } returns 31.2357
+        }
+        val locationPrefs = mockk<com.app.azkary.data.prefs.LocationPreferences> {
+            every { useLocation } returns true
+            every { lastResolvedLocation } returns mockLocation
+        }
+        val expectedDate = LocalDate.of(1447, 8, 15)
+
+        every { userPreferencesRepository.locationPreferences } returns flowOf(locationPrefs)
+        coEvery { prayerTimesRepository.getIslamicCurrentDate(30.0444, 31.2357) } returns expectedDate
+
+        islamicDateProvider.refreshDate()
+
+        assertEquals(expectedDate, islamicDateProvider.currentDateFlow.value)
+    }
+
+    @Test
+    fun `refreshDate should fallback to Gregorian date on error`() = runTest {
+        val mockLocation = mockk<LatLng> {
+            every { latitude } returns 30.0444
+            every { longitude } returns 31.2357
+        }
+        val locationPrefs = mockk<com.app.azkary.data.prefs.LocationPreferences> {
+            every { useLocation } returns true
+            every { lastResolvedLocation } returns mockLocation
+        }
+
+        every { userPreferencesRepository.locationPreferences } returns flowOf(locationPrefs)
+        coEvery { prayerTimesRepository.getIslamicCurrentDate(any(), any()) } throws RuntimeException("Error")
+
+        islamicDateProvider.refreshDate()
+
+        assertEquals(LocalDate.now(), islamicDateProvider.currentDateFlow.value)
+    }
 }
+

--- a/app/src/test/java/com/app/azkary/ui/reading/ReadingViewModelTest.kt
+++ b/app/src/test/java/com/app/azkary/ui/reading/ReadingViewModelTest.kt
@@ -100,11 +100,15 @@ class ReadingViewModelTest {
         every { userPreferencesRepository.holdToComplete } returns MutableStateFlow(true)
         every { userPreferencesRepository.vibrationEnabled } returns MutableStateFlow(true)
         coEvery { islamicDateProvider.getCurrentDate() } returns testDate
-        every { 
-            repository.observeItemsForCategory(any(), any(), any()) 
+        every { islamicDateProvider.currentDateFlow } returns MutableStateFlow(testDate)
+        coEvery { islamicDateProvider.refreshDate() } coAnswers {
+            // Simulate refreshDate updating the flow - no-op in tests since we use a MutableStateFlow
+        }
+        every {
+            repository.observeItemsForCategory(any(), any(), any())
         } returns flowOf(testItems)
-        every { 
-            repository.getWeightedProgress(any(), any(), any()) 
+        every {
+            repository.getWeightedProgress(any(), any(), any())
         } returns flowOf(0.5f)
 
         viewModel = ReadingViewModel(
@@ -326,6 +330,7 @@ class ReadingViewModelTest {
     fun `incrementRepeat should use current date from islamicDateProvider`() = runTest {
         val customDate = LocalDate.of(2026, 3, 15)
         coEvery { islamicDateProvider.getCurrentDate() } returns customDate
+        every { islamicDateProvider.currentDateFlow } returns MutableStateFlow(customDate)
         coEvery { repository.incrementRepeat(any(), any(), any()) } just Runs
 
         // Recreate viewModel with custom date

--- a/app/src/test/java/com/app/azkary/ui/summary/SummaryViewModelTest.kt
+++ b/app/src/test/java/com/app/azkary/ui/summary/SummaryViewModelTest.kt
@@ -107,8 +107,12 @@ class SummaryViewModelTest {
             LocationPreferences(useLocation = false, lastResolvedLocation = null, locationName = null)
         )
         coEvery { islamicDateProvider.getCurrentDate() } returns testDate
-        every { 
-            repository.observeCategoriesWithDisplayName(any(), any()) 
+        every { islamicDateProvider.currentDateFlow } returns MutableStateFlow(testDate)
+        coEvery { islamicDateProvider.refreshDate() } coAnswers {
+            // Simulate refreshDate updating the flow - no-op in tests since we use a MutableStateFlow
+        }
+        every {
+            repository.observeCategoriesWithDisplayName(any(), any())
         } returns flowOf(testCategories)
         coEvery { 
             prayerTimesRepository.getCurrentWindows(any(), any(), any(), any()) 


### PR DESCRIPTION
## Problem

When the user left the app on a zikr reading page and the day changed (e.g., overnight), reopening the app crashed. The root cause was that todayFlow in ReadingViewModel was a one-shot cold flow that emitted the Islamic date once and never re-emitted.

**Crash scenario:**
1. User opens reading screen on Day A - todayFlow emits Day A
2. App goes to background, Android kills the process
3. Day changes to Day B
4. User reopens the app - ViewModel is recreated
5. items StateFlow starts with emptyList() (pageCount = 0)
6. HorizontalPager has currentPage restored from saved state > 0 but pageCount is 0
7. Crash: IllegalArgumentException / IndexOutOfBoundsException

**Secondary bug - read/write date mismatch:**
- Reads (items, weightedProgress) used the stale todayFlow date
- Writes (incrementRepeat, markItemComplete) called getCurrentDate() fresh
- Result: user taps appeared to have no effect (progress written to new date, UI observing old date)

## Solution

1. **IslamicDateProvider** - Added reactive currentDateFlow StateFlow and refreshDate() method
2. **ReadingViewModel** - Replaced one-shot todayFlow with currentDateFlow.filterNotNull().map; write operations now read from currentDateFlow.value
3. **SummaryViewModel** - Same reactive date pattern applied
4. **MainActivity** - Added islamicDateProvider.refreshDate() in onResume() to detect day changes when app returns to foreground

## Files Changed

- \IslamicDateProvider.kt\ - Added currentDateFlow StateFlow and refreshDate()
- \ReadingViewModel.kt\ - Reactive todayFlow; refreshDate() in init; consistent date reads in writes
- \SummaryViewModel.kt\ - Same reactive pattern; refreshDate() in init; toggleCategoryCompletion fix
- \MainActivity.kt\ - Injected IslamicDateProvider; refreshDate() in onResume()
- \IslamicDateProviderTest.kt\ - Added tests for currentDateFlow and refreshDate()
- \ReadingViewModelTest.kt\ - Added currentDateFlow and refreshDate() mocks
- \SummaryViewModelTest.kt\ - Added currentDateFlow and refreshDate() mocks

## Testing

- Build: assembleDebug passed
- Unit tests: IslamicDateProviderTest, ReadingViewModelTest, SummaryViewModelTest all pass